### PR TITLE
fix(*): newline character for exception backtraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] 2019-07-17
+### Fixed:
+- Newline character for exception backtraces.
+
 ## [0.1.1] 2019-07-17
 ### Fixed:
 - Log exception backtraces.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    super-flux (0.1.0)
+    super-flux (0.1.2)
       concurrent-ruby
       ruby-kafka
       super

--- a/lib/super/flux/reactor/execute_task.rb
+++ b/lib/super/flux/reactor/execute_task.rb
@@ -13,7 +13,7 @@ module Super
           consumer.mark_message_as_processed(message)
           true
         rescue StandardError => e
-          message = [e.message, *e.backtrace].join('\n')
+          message = [e.message, *e.backtrace].join("\n")
           logger.error(message)
           false
         end

--- a/lib/super/flux/reactor/retry_task.rb
+++ b/lib/super/flux/reactor/retry_task.rb
@@ -14,7 +14,7 @@ module Super
           consumer.mark_message_as_processed(message)
           true
         rescue StandardError => e
-          message = [e.message, *e.backtrace].join('\n')
+          message = [e.message, *e.backtrace].join("\n")
           logger.error(message)
           false
         end

--- a/lib/super/flux/version.rb
+++ b/lib/super/flux/version.rb
@@ -2,6 +2,6 @@
 
 module Super
   module Flux
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
## [0.1.2] 2019-07-17
### Fixed:
- Newline character for exception backtraces.