### PR TITLE
fix(flusher.rb): trigger flusher execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] 2019-07-19
+### Fixed:
+- Flusher execution.
+
 ## [0.1.2] 2019-07-17
 ### Fixed:
 - Newline character for exception backtraces.

--- a/lib/super/flux/producer.rb
+++ b/lib/super/flux/producer.rb
@@ -45,6 +45,7 @@ module Super
 
         def shutdown
           buffer.flush
+          flusher.stop
           producer.shutdown
         end
 

--- a/lib/super/flux/producer/flusher.rb
+++ b/lib/super/flux/producer/flusher.rb
@@ -16,6 +16,7 @@ module Super
           @task = Concurrent::TimerTask.new(TASK_OPTIONS) do |_task|
             flush
           end
+          @task.execute
         end
 
         def flush


### PR DESCRIPTION
Flusher was not being executed. Causing the producer only send the messages when reaching the buffer size.

```bash
15:56 $ irb
irb(main):001:0> require 'concurrent-ruby'
=> true
irb(main):002:0> task = Concurrent::TimerTask.new(run_now: true, execution_interval: 1, timeout_interval: 1) { p 'Running!' }
=> #<Concurrent::TimerTask:0x00007fdc66040d40 @__Lock__=#<Thread::Mutex:0x00007fdc66040ca0>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040c78>, @dup_on_deref=nil, @freeze_on_deref=nil, @copy_on_deref=nil, @do_nothing_on_deref=true, @execution_interval=1.0, @timeout_interval=1.0, @run_now=true, @executor=#<Concurrent::SafeTaskExecutor:0x00007fdc66040bb0 @task=#<Proc:0x00007fdc66040c00@(irb):2>, @exception_class=StandardError, @__Lock__=#<Thread::Mutex:0x00007fdc66040b38>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040b10>>, @running=#<Concurrent::AtomicBoolean:0x00007fdc66040ac0 value:false>, @value=nil, @observers=#<Concurrent::Collection::CopyOnNotifyObserverSet:0x00007fdc660409f8 @__Lock__=#<Thread::Mutex:0x00007fdc660409a8>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040980>, @observers={}>, @StopEvent=#<Concurrent::Event:0x00007fdc660408e0 @__Lock__=#<Thread::Mutex:0x00007fdc66040890>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040868>, @set=false, @iteration=0>, @StoppedEvent=#<Concurrent::Event:0x00007fdc66040818 @__Lock__=#<Thread::Mutex:0x00007fdc660407c8>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc660407a0>, @set=false, @iteration=0>>
irb(main):003:0> task.execute
=> #<Concurrent::TimerTask:0x00007fdc66040d40 @__Lock__=#<Thread::Mutex:0x00007fdc66040ca0>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040c78>, @dup_on_deref=nil, @freeze_on_deref=nil, @copy_on_deref=nil, @do_nothing_on_deref=true, @execution_interval=1.0, @timeout_interval=1.0, @run_now=true, @executor=#<Concurrent::SafeTaskExecutor:0x00007fdc66040bb0 @task=#<Proc:0x00007fdc66040c00@(irb):2>, @exception_class=StandardError, @__Lock__=#<Thread::Mutex:0x00007fdc66040b38>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040b10>>, @running=#<Concurrent::AtomicBoolean:0x00007fdc66040ac0 value:true>, @value=nil, @observers=#<Concurrent::Collection::CopyOnNotifyObserverSet:0x00007fdc660409f8 @__Lock__=#<Thread::Mutex:0x00007fdc660409a8>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040980>, @observers={}>, @StopEvent=#<Concurrent::Event:0x00007fdc660408e0 @__Lock__=#<Thread::Mutex:0x00007fdc66040890>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc66040868>, @set=false, @iteration=0>, @StoppedEvent=#<Concurrent::Event:0x00007fdc66040818 @__Lock__=#<Thread::Mutex:0x00007fdc660407c8>, @__Condition__=#<Thread::ConditionVariable:0x00007fdc660407a0>, @set=false, @iteration=0>>
"Running!"
irb(main):004:0> "Running!"
"Running!"
```